### PR TITLE
fix rp2040 critical timing when sending handshake

### DIFF
--- a/src/pio_usb_host.c
+++ b/src/pio_usb_host.c
@@ -212,8 +212,8 @@ static void __no_inline_not_in_flash_func(restore_fs_bus)(pio_port_t *pp) {
 
 // Time about 1us ourselves so it lives in RAM.
 static void __not_in_flash_func(busy_wait_1_us)(void) {
-  uint32_t start = time_us_32();
-  while (time_us_32() == start) {
+  uint32_t start = get_time_us_32();
+  while (get_time_us_32() == start) {
       tight_loop_contents();
   }
 }

--- a/src/usb_crc.h
+++ b/src/usb_crc.h
@@ -13,3 +13,10 @@ static inline uint16_t __time_critical_func(update_usb_crc16)(uint16_t crc, uint
   crc = (crc >> 8) ^ crc16_tbl[(crc ^ data) & 0xff];
   return crc;
 }
+
+#ifndef PICO_DEFAULT_TIMER_INSTANCE // not defined in sdk v1
+#define PICO_DEFAULT_TIMER_INSTANCE() timer_hw
+#endif
+
+// time_us_32() not force inline and may be in flash, implement timestamp ourselves
+#define get_time_us_32()  (PICO_DEFAULT_TIMER_INSTANCE()->timerawl)


### PR DESCRIPTION
@tannewt from receiving EOP to sennding handshake is time critical, having pio_usb_bus_wait_packet() as subfunction cause rp2040 not sending handshake in time (rp2040 run slower than rp2350) and cause timeout on device side. This PR resolve this by
- separate pio_usb_bus_wait_handshake() & pio_usb_bus_receive_packet_and_handshake() to avoid function call. Also the wait_handsahke() does not need to compute crc, that will make it complete quicker.
- add pio_usb_bus_wait_for_rx_start() as force inline, which should be in ram since both caller are in ram
- add get_time_us_32() define: since time_us_32() is not forceinline and be in flash.
